### PR TITLE
macos M1 models are arm64...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,8 @@ ifeq ($(detected_OS),Windows)
 else ifeq ($(detected_OS),Darwin)
 	echo "Installing for macOS $(UNAME_M)..."
 	cp ocicl ${DESTDIR}/bin ;
-ifeq ($(UNAME_M),x86_64)
-		tar xvf oras/oras_1.0.0_darwin_amd64.tar.gz -C /tmp oras > /dev/null 2>&1;
-else ifeq ($(UNAME_M),arm)
-		tar xvf oras/oras_1.0.0_darwin_arm64.tar.gz -C /tmp oras > /dev/null 2>&1;
+ifneq (,$(findstring $(UNAME_M),x86_64 arm arm64))
+		tar xvf oras/oras_1.0.0_darwin_$(UNAME_M).tar.gz -C /tmp oras > /dev/null 2>&1;
 else
 		echo "Unsupport macOS type: $(UNAME_M)"
 endif


### PR DESCRIPTION
as it already have x86_64 and arm,
all cases are pretty much the same.

the only change was the arch on the tar file name
and the list of possible archtectures.