### PR TITLE
Fix installation under Wine + MinGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install:
 	echo $(detected_OS)
 ifeq ($(detected_OS),Windows)
 	echo "Installing for Windows..."
-	cp ocicl.exe ${DESTDIR}/bin ;
+	cp ocicl.exe ${DESTDIR}/bin
 	unzip oras/oras_1.0.0_windows_amd64.zip oras.exe
 	cp oras.exe ${DESTDIR}/bin/ocicl-oras.exe
 else ifeq ($(detected_OS),Darwin)


### PR DESCRIPTION
Hey! This small PR fixes ocicl installation under Wine with MiGW — it looks like its cp.exe does not like the semicolon very much:
```
cp ocicl.exe /ucrt64/bin ;
cp: can't create ';/ocicl.exe': No such file or directory
cp: omitting directory '/ucrt64/bin'
```

Withoit the semicolon it works fine.