### PR TITLE
Fix macOS installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,16 @@ ifeq ($(detected_OS),Windows)
 else ifeq ($(detected_OS),Darwin)
 	@echo "Installing for macOS $(UNAME_M)..."
 	cp ocicl ${DESTDIR}/bin ;
-  case $(UNAME_M) in
-	  x86_64|amd64)
-			tar xvf oras/oras_1.0.1_darwin_amd64.tar.gz -C /tmp oras > /dev/null 2>&1;
-		arm64)
-			tar xvf oras/oras_1.0.1_darwin_arm64.tar.gz -C /tmp oras > /dev/null 2>&1;
-		*)
-			echo "Unsupport macOS type: $(UNAME_M)";
-  esac
+	@case ${UNAME_M} in \
+		x86_64|amd64) \
+			tar xvf oras/oras_1.0.1_darwin_amd64.tar.gz -C /tmp oras > /dev/null 2>&1; \
+			;;\
+		arm64) \
+			tar xvf oras/oras_1.0.1_darwin_arm64.tar.gz -C /tmp oras > /dev/null 2>&1; \
+			;;\
+		*) \
+			echo "Unsupport macOS type: $(UNAME_M)"; \
+	esac; \
 	mv /tmp/oras ${DESTDIR}/bin/ocicl-oras
 else
 	@echo "Installing for Linux..."


### PR DESCRIPTION
Multi-line shell commands in make targets need some special escaping.

`make install` runs without error and extracts the correct tarball. 

Fixes: #19 