### PR TITLE
fix: correctly read ocicl-globaldir.cfg

### DIFF
--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -263,7 +263,7 @@ Distributed under the terms of the MIT License"
 
   (let ((config-file (merge-pathnames (get-ocicl-dir) "ocicl-globaldir.cfg")))
     (when (probe-file config-file)
-      (setf *ocicl-globaldir* (uiop:read-file-string config-file))))
+      (setf *ocicl-globaldir* (uiop:ensure-absolute-pathname (uiop:read-file-line config-file)))))
 
   (let ((workdir (uiop:getcwd)))
 


### PR DESCRIPTION
UIOP:READ-FILE-STRING returns all content and a trailing newline, making the following calling to UIOP:CHDIR to fail. Changing this to UIOP:READ-FILE-LINE as it doesn't make much sense to allow multiple lines in the file anyway.