### PR TITLE
Add a *global-only* parameter to the runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ performing any operation with the `ocicl` cli.  These "global" systems
 are available at runtime using the following heuristic:
 - If the system is available locally, then it is loaded from from the local `systems` directory.
 - Else if the system is available in the global `systems` directory, it loaded from there.
-- Otherwise, if `ocicl-runtime:*download*` is non-nil, then the system is downloaded and installed locally.
+- Otherwise, if `ocicl-runtime:*download*` is non-nil, then the system is downloaded either locally or globally:
+    - if `ocicl-runtime:*force-global*` is non-nil, then the system is downloaded to the global systems directory.
+    - else if `ocicl-runtime:*force-global*` is nil (default), then the system is downloaded locally.
 
 To change the default user-global directory, provide the
 optional ``GLOBALDIR`` argument when you invoke ``ocicl setup``.

--- a/runtime/ocicl-runtime.lisp
+++ b/runtime/ocicl-runtime.lisp
@@ -27,13 +27,13 @@
 
 (defpackage #:ocicl-runtime
   (:use #:cl)
-  (:export #:*download* #:*verbose* #:+version+ #:system-list))
+  (:export #:*download* #:*verbose* #:*force-global* #:+version+ #:system-list))
 
 (in-package #:ocicl-runtime)
 
 (defvar *download* t)
 (defvar *verbose* nil)
-
+(defvar *force-global* nil)
 (defconstant +version+ "UNKNOWN")
 
 (defvar *local-ocicl-systems* nil)
@@ -99,7 +99,10 @@
 
 (defun ocicl-install (name)
   (check-ocicl-version)
-  (let ((cmd (format nil "ocicl ~A install ~A" (if *verbose* "-v" "") name)))
+  (let ((cmd (format nil "ocicl ~A ~A install ~A"
+                     (if *verbose* "-v" "")
+                     (if *force-global* "--global" "")
+                     name)))
     (when *verbose* (format t "; running: ~A~%" cmd))
     (uiop:run-program cmd
                       :output (if *verbose* *standard-output*


### PR DESCRIPTION
This should make it easier to use ocicl in a global-only manner.

Please change the `*global-only*` to another name if that's more taste-appropriate.

PS: My current pet-peeve is that ocicl tries to create a `systems.csv` and the `systems` directory in every damn directory I start the lisp process in. This PR resolves this issue.