### PR TITLE
Ensure OCICL_PREFIX env variable is a directory

### DIFF
--- a/setup.lisp
+++ b/setup.lisp
@@ -12,8 +12,8 @@
                              ((uiop:os-windows-p)
                               (format nil "~A\\AppData\\Local\\ocicl\\"
                                       (uiop:getenv "UserProfile")))
-                             ((uiop:getenv "OCICL_PREFIX")
-                              (uiop:getenv "OCICL_PREFIX"))
+                             ((uiop:getenvp "OCICL_PREFIX")
+                              (uiop:ensure-directory-pathname (uiop:getenv "OCICL_PREFIX")))
                              (t "~/.local/")))
     (defconstant +ocicl-bin-name+ (if (uiop:os-windows-p) "ocicl.exe" "ocicl"))))
 


### PR DESCRIPTION
Hi @atgreen ,

I was a little absent and had to start from scratch building `ocicl` and stumbled over a problem an thought I may improve it. 

Just two little changes. 

1. Use `uiop:ensure-directory-pathname` on `OCICL_PREFIX` to ensure we're working with a directory path (😅) when creating sub-directories. 

Without the trailing slash, the `bin` directory is added before the last path segment:
```lisp
CL-USER> (merge-pathnames (make-pathname :directory '(:relative "bin")) 
                          "/home/foo/software/ocicl-2.3.9")
#P"/home/foo/software/bin/ocicl-2.3.9"
                      ^^^
```

2. Use `uiop:getenvp` because it returns `nil` when the env variable is empty, as well. 