### PR TITLE
Don't overwrite config if present

### DIFF
--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -219,7 +219,7 @@ Distributed under the terms of the MIT License"
 
   (with-open-file (stream (merge-pathnames (get-ocicl-dir) "ocicl-registry.cfg")
                           :direction :output
-                          :if-exists :supersede)
+                          :if-exists nil)
     (write-string (first *ocicl-registries*) stream))
   (if args
     (let ((original-directory (uiop:getcwd)))

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -216,11 +216,11 @@ Distributed under the terms of the MIT License"
   (format t "ASDF version:    ~A~%" (asdf:asdf-version)))
 
 (defun do-setup (args)
-
-  (with-open-file (stream (merge-pathnames (get-ocicl-dir) "ocicl-registry.cfg")
-                          :direction :output
-                          :if-exists nil)
-    (write-string (first *ocicl-registries*) stream))
+  (unless (probe-file (merge-pathnames (get-ocicl-dir) "ocicl-registry.cfg"))
+    (with-open-file (stream (merge-pathnames (get-ocicl-dir) "ocicl-registry.cfg")
+                            :direction :output
+                            :if-exists :error)
+      (write-string (first *ocicl-registries*) stream)))
   (if args
     (let ((original-directory (uiop:getcwd)))
       (unwind-protect


### PR DESCRIPTION
I had multiple registries configured in `ocicl-registry.cfg` which were discarded after `setup` ran again while building a new executable. 

I think that, once the configuration was created, `ocicl` shouldn't touch it again and overwrite any existing configuration with default values.

What do you think @atgreen? 

