### PR TITLE
Compile bundled ASDF and muffle redefinition warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,8 +430,9 @@ a directory in which you cloned various lisp systems called
 interesting log info.
 
 * ``ocicl`` is bundled with ``asdf`` version 3.3.7.  You can delete it
-from the directory containing ``ocicl-runtime.lisp`` if you do not
-want this version to be loaded by the runtime at startup.
+(along with any fasl files) from the directory containing
+``ocicl-runtime.lisp`` if you do not want this version to be loaded by
+the runtime at startup.
 
 Author and License
 -------------------


### PR DESCRIPTION
1. Check if `(require 'asdf)` already satisfies ASDF version requirement. I decided to use 3.3.5 because mentioned [here](https://github.com/ocicl/ocicl/issues/67#issuecomment-2294900303)
2. Compile the bundle `asdf.lisp` and cache the fasl file based on implementation and machine type. Loading the fasl file is faster than loading the lisp file. 
3. Muffle annoying redefinition warnings when loading bundled ASDF.