### PR TITLE
feat: enhance *verbose* to allow for different output streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ a directory in which you cloned various lisp systems called
 ```
 (asdf:initialize-source-registry '(:source-registry :inherit-configuration (:tree #P"/path/to/my/local-projects/")))
 ```
-* Setting ``ocicl-runtime:*verbose*`` to ``t`` will output useful and
+* Setting ``ocicl-runtime:*verbose*`` to a stream (like ``t``, ``*standard-output*``, ``*error-output*``, etc) will output useful and
 interesting log info.
 
 * ``ocicl`` is bundled with ``asdf`` version 3.3.7.  You can delete it

--- a/runtime/ocicl-runtime.lisp
+++ b/runtime/ocicl-runtime.lisp
@@ -249,7 +249,7 @@
 
 (defun system-definition-searcher (name)
   (unless (or (starts-with? "asdf" name) (string= "uiop" name))
-    (let* ((*verbose* (or *verbose* (and asdf:*verbose-out* t)))
+    (let* ((*verbose* (or *verbose* asdf:*verbose-out*))
            (system-file (find-asdf-system-file name *download*)))
       (when (and system-file
                  (string= (pathname-name system-file) name))


### PR DESCRIPTION
I found it bothersome that `*verbose*` literally translated to `t` when invoking `FORMAT`. I should be in control of where ocicl logs to, and in some cases, I want `*error-output*` or my own file.

- Add `SHOULD-LOG` which checks if *verbose* is non-nil and a valid
output stream.
- Replace direct `t` `FORMATS` with `*verbose*`, if `SHOULD-LOG` permit.