### PR TITLE
Implement ocicl remove, minor fix to download-system

### DIFF
--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -739,7 +739,7 @@ Distributed under the terms of the MIT License"
   (let* ((slist (split-on-delimeter system #\:))
          (name (car slist))
          (mangled-name (mangle name))
-         (system-info (gethash name *ocicl-systems*))
+         (system-info (gethash mangled-name *ocicl-systems*))
          (fullname (car system-info))
          (relative-asd-path (cdr system-info))
          (existing-version (when system-info


### PR DESCRIPTION
Implements #90, examples using this repository:

- Adds helper functions `unmangle` and `system-group`
- `ocicl remove` removes top level systems unconditionally. Prints "full names" removed. Example:
    ``` sh
    $ grep cl+ssl systems.csv
    cl_plus_ssl.test, ghcr.io/ocicl/cl_plus_ssl@sha256:acb61e8...
    cl_plus_ssl, ghcr.io/ocicl/cl_plus_ssl@sha256:acb61e8...

    $ ocicl remove cl+ssl
    ; removed cl_plus_ssl@sha256:acb61e8e4d3efcb23f4d86405ad22fdca2d685268c664735c962646a09706ab6

   $ grep cl+ssl systems.csv
    # no output
    ```

- `ocicl autoremove` removes systems only if they are known not to be depended on by other systems in systems.csv. Example:
   ```sh
   $ ocicl autoremove usocket
   ; not removing systems (usocket-server usocket-test usocket), depended on by one of: (cl+ssl cl+ssl.test)


   $ ocicl autoremove tar
   ; removed tar@sha256:66dfa78c17d2cc74973e6232f2687e9c9e5d16a479e5278257ad58f0ac6f8955
   ; removed tar-file@sha256:5f8c99e73924abdc4a59de9d38c73f5e574aebebc8cbc25df73e8b3fa4dde131
   ; removed salza2@sha256:0f9d930524b469e1442372a6e12b26742d9e6a1144e6a455006943190d1ea71e
   ; removed 40ants-doc@sha256:a6b40bcd273f9341247e6b12665a5edc1bcfea86fe480cde476b9ff0e1cf3660
   ; not removing systems (trivial-gray-streams-test trivial-gray-streams), depended on by one of: (dexador-test dexador-usocket dexador)
   ; not removing systems (flexi-streams-test flexi-streams), depended on by one of: (dexador-test dexador-usocket dexador)
   ; not removing systems (chipz), depended on by one of: (dexador-test dexador-usocket dexador)
   ; not removing systems (alexandria), depended on by one of: (dexador-test dexador-usocket dexador)
   ; not removing systems (trivial-features-tests trivial-features), depended on by one of: (cffi-examples cffi-grovel cffi-libffi cffi-tests cffi-toolchain cffi-uffi-compat cffi uffi)
   ; not removing systems (babel-streams babel-tests babel), depended on by one of: (dexador-test dexador-usocket dexador)
   ; not removing systems (split-sequence), depended on by one of: (quri-test quri)
   ; not removing systems (cl-postgres+local-time local-time), depended on by one of: (cl-cookie-test cl-cookie)


   $ ocicl autoremove dexador
   ; removed dexador@sha256:d1e8ca389d304fcab5d05a85015b9b75d98c9aab3618c9e895a12dee278b6122
   ; removed fast-http@sha256:44e98b5239c0ded4921dc0b04ae272cff00583d93797a657543db782979eb50c
   ; removed smart-buffer@sha256:b8d194f5881c415fd7f0099b88dfd9e2158405c2966de15c716b155a364bf0f7
   ; removed xsubseq@sha256:7605d14f7cc7fd2f63190ad81fe7bd65daef105d6728ee6bb59baef49da2aa51
   ; removed fast-io@sha256:7ba35a0eddf00b3c25656b3c5a93e95460f6cb8f807afbc04ef4f50076d95aff
   ; removed static-vectors@sha256:53e11e5689c3dbea6a3017760b55f052588003d774913539930ddc4330a69970
   ; removed chunga@sha256:a59ccb3d13992748c676b8e3263256850ee626f98ac59adece5a142967b6f558
   ; removed cl-cookie@sha256:85cd8aa7f1379d041fae9530609cd68d5214fb978bc87faa7fd9ad5ad7e08a83
   ; removed proc-parse@sha256:0880f9acb35eb9efbe1f77a981e36e84e8f29a22b14f680c7686eb381fa87bd6
   ; removed cl-ppcre@sha256:584907e0683621973579f397115945ef73e9d5b7afa77fae7cacecb3ad272f89
   ; removed quri@sha256:e2559f91600e4895e115b42dde88fcaac3677f051335d73431888dcf7af99f95
   ; removed cl-utilities@sha256:e5e0676a4e0627332a0fe64d56ed4f1890f0466d715a11e8d95561b4c2baa38f
   ; removed trivial-mimes@sha256:b33ae6d62bcd666d046e4ae1625b8e8b46a548fe2c4f18b4899ce1ecf581c17b
   ; removed cl-base64@sha256:702412dbc1ed825e275fb23e22c29527eb786bf644e47c7621bf0dbb34e17c7e
   ; removed cl_plus_ssl@sha256:acb61e8e4d3efcb23f4d86405ad22fdca2d685268c664735c962646a09706ab6
   ; removed cffi@sha256:fe1246d11c4c067daefdb143e1252e0f3e99046909185d2c920adb8323318742
   ; removed usocket@sha256:015b8cdb91cdc25aefd08054e8ede6a5d054d10bc87916904cf0d0670b3f4a68
   ; removed global-vars@sha256:d197e871c9c9abc4bf31b1186f5fd28f0ca848ebe2e9dddf2d82ecee01dbdc65
   ; removed trivial-features@sha256:e278e24d39060fc7d3715531b16ddd9ab7f93f22ade53e436c0b86dbae3aa065
   ; removed trivial-garbage@sha256:a85dcf4110ad60ae9f6c70970acceb2bf12402ce5326891643d35506059afb1d
   ; not removing systems (alexandria), depended on by one of: (tar-cli-asdf tar-cli tar)
   ; not removing systems (bordeaux-threads), depended on by one of: (cl-fad)
   ; not removing systems (split-sequence), depended on by one of: (tar-cli-asdf tar-cli tar)
   ; not removing systems (trivial-gray-streams-test trivial-gray-streams), depended on by one of: (tar-file)
   ; not removing systems (flexi-streams-test flexi-streams), depended on by one of: (tar-file)
   ; not removing systems (babel-streams babel-tests babel), depended on by one of: (tar-cli-asdf tar-cli tar)
   ; not removing systems (chipz), depended on by one of: (tar-file)
   ; not removing systems (cl-postgres+local-time local-time), depended on by one of: (tar-cli-asdf tar-cli tar)
   ```

- Fixes a bug where `download-system` was not using the mangled name, so systems like cl+ssl would always be downloaded
-  Fixes most compile time warnings in ocicl.lisp. (There's one about unreachable code in the `+runtime+` parameter I left since I wasn't exactly sure how it should be handled

