### PR TITLE
Add ability to rename systems.csv and systems directory

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,11 +28,11 @@ jobs:
         shell: bash
       - name: Test
         run: |
-          rm -rf systems systems.csv
+          rm -rf systems systems.ocicl
           mkdir test
           cd test
           ocicl install sento
-          cat systems.csv
+          cat systems.ocicl
           ls -l systems
           sbcl --non-interactive --eval "(asdf:load-system :sento)" --eval "(quit)"
           sbcl --non-interactive --eval "(asdf:load-system :cl-etcd)" --eval "(quit)"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,12 +28,14 @@ jobs:
         shell: bash
       - name: Test
         run: |
-          rm -rf systems systems.ocicl
+          rm -rf systems systems.csv
           mkdir test
           cd test
+          touch systems.ocicl
           ocicl install sento
-          cat systems.ocicl
           ls -l systems
+          ls -l systems.ocicl
+          cat systems.ocicl
           sbcl --non-interactive --eval "(asdf:load-system :sento)" --eval "(quit)"
           sbcl --non-interactive --eval "(asdf:load-system :cl-etcd)" --eval "(quit)"
           rm -rf systems

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,11 +28,11 @@ jobs:
         shell: bash
       - name: Test
         run: |
-          rm -rf systems systems.csv
+          rm -rf systems systems.ocicl
           mkdir test
           cd test
           ocicl install sento
-          cat systems.csv
+          cat systems.ocicl
           ls -l systems
           sbcl --non-interactive --eval "(asdf:load-system :sento)" --eval "(quit)"
           sbcl --non-interactive --eval "(asdf:load-system :cl-etcd)" --eval "(quit)"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,12 +28,14 @@ jobs:
         shell: bash
       - name: Test
         run: |
-          rm -rf systems systems.ocicl
+          rm -rf systems systems.csv
           mkdir test
           cd test
+          touch systems.ocicl
           ocicl install sento
-          cat systems.ocicl
           ls -l systems
+          ls -l systems.ocicl
+          cat systems.ocicl
           sbcl --non-interactive --eval "(asdf:load-system :sento)" --eval "(quit)"
           sbcl --non-interactive --eval "(asdf:load-system :cl-etcd)" --eval "(quit)"
           rm -rf systems

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test
         run: |
           export PATH=/c/Users/runneradmin/AppData/Local/ocicl/bin:$PATH
-          rm -rf systems systems.ocicl
+          rm -rf systems systems.csv
           mkdir test
           cd test
           touch systems.ocicl

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,15 +41,15 @@ jobs:
       - name: Test
         run: |
           export PATH=/c/Users/runneradmin/AppData/Local/ocicl/bin:$PATH
-          rm -rf systems systems.csv
+          rm -rf systems systems.ocicl
           mkdir test
           cd test
-          touch systems.csv
+          touch systems.ocicl
           mkdir systems
           ocicl.exe -v install sento
           ls -l systems
-          ls -l systems.csv
-          cat systems.csv
+          ls -l systems.ocicl
+          cat systems.ocicl
           ls -l systems
           /c/sbcl/Pfiles/"Steel Bank Common Lisp"/sbcl.exe --non-interactive --eval "(asdf:load-system :sento)" --eval "(quit)"
           /c/sbcl/Pfiles/"Steel Bank Common Lisp"/sbcl.exe --non-interactive --eval "(asdf:load-system :cl-etcd)" --eval "(quit)"


### PR DESCRIPTION
New logic:

- If a file `<name>.ocicl` exists, use that as the systems.csv and use `<name>/` as the systems directory (where `<name>` can be anything)
- If `systems.csv` exists, use that with `systems/` to retain backward compatibility
- Default to `systems.ocicl` with `systems/`

This is just a possible implementation of #60. I am curious what those interested in that ticket think of this approach? @digikar99 @rudolfochrist @mdbergmann