### PR TITLE
Fix ocicl install sometimes not installing dependencies

### DIFF
--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -1169,9 +1169,9 @@ download the system unless a version is specified."
             (uiop:delete-directory-tree dl-dir :validate t))))))
 
 (defun find-asdf-system-file (name)
-  (let ((known-system (gethash (mangle name) *ocicl-systems*)))
-    (cond (known-system
-           (probe-file (merge-pathnames (cdr known-system) *systems-dir*)))
+  (let* ((system-info (gethash (mangle name) *ocicl-systems*))
+         (system-asd (when system-info (merge-pathnames (cdr system-info) *systems-dir*))))
+    (cond ((and system-asd (probe-file system-asd)))
           ((not *inhibit-download-during-search*)
            (handler-case
                (probe-file (merge-pathnames (cdr (download-system name)) *systems-dir*))


### PR DESCRIPTION
When a system was present in systems.csv, but did not exist in the systems directory, ocicl's system searcher would not attempt to download the file.

Fixes #109