### PR TITLE
Do more complete dependency resolution in ocicl remove

### DIFF
--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -1246,8 +1246,9 @@ download the system unless a version is specified."
       (append asdf:*system-definition-search-functions*
               (list 'system-definition-searcher)))
 
-;; Register known internal SBCL systems as "immutable" so that find-system
-;; inside the ocicl executable does not try to load them
+
+;; Register known internal systems as "immutable" so that find-system inside
+;; the ocicl executable does not try to load them
 (dolist (system '(:sb-aclrepl
                   :sb-bsd-sockets
                   :sb-capstone
@@ -1267,7 +1268,21 @@ download the system unless a version is specified."
                   :sb-rt
                   :sb-simd
                   :sb-simple-streams
-                  :sb-sprof))
+                  :sb-sprof
+
+                  ;; Register some non-SBCL internal systems that don't exist
+                  ;; in the ocicl repo
+
+                  ;; corman
+                  :threads
+                  ;; clisp
+                  :syscalls
+                  ;; abcl
+                  :extensible-sequences
+                  ;; cmucl
+                  :unix
+                  ;; allegro
+                  :osi))
   (asdf:register-immutable-system system))
 
 (asdf/system-registry:clear-registered-systems)

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -1061,25 +1061,16 @@ Distributed under the terms of the MIT License"
     (merge-pathnames (eval `(make-pathname :directory '(:relative ,rdir)))
                      (uiop:default-temporary-directory))))
 
+(declaim (inline find-asd-files))
 (defun find-asd-files (dir)
   "Recursively find all files with the .asd extension in a directory."
   ;; Force a trailing slash to support uiop change in behavior:
   ;; https://github.com/fare/asdf/commit/6138d709eb25bf75c1d1f7dc45a63d174f982321
-  (let* ((dir (namestring dir))
-         (dir (if (string= (subseq dir (- (length dir) 1)) "/")
-                 dir
-                 (concatenate 'string dir "/")))
-         (systems (list)))
-    (labels ((push-asd (dir)
-               (debug-log #?"searching ${dir}")
-               (dolist (f (uiop:directory-files dir))
-                 (when (equal "asd" (pathname-type f))
-                   (pushnew f systems)))))
-      (uiop:collect-sub*directories dir
-                                    t t
-                                    (lambda (d) (push-asd d)))
-      (push-asd dir))
-    systems))
+  (directory (merge-pathnames
+              (make-pathname :name :wild
+                             :type "asd"
+                             :directory '(:relative :wild-inferiors))
+              (uiop:ensure-directory-pathname dir))))
 
 (defun extract-sha256 (str)
   (let* ((start (search "sha256:" str))

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -267,7 +267,7 @@ Distributed under the terms of the MIT License"
 
 (defun download-system-dependencies (name)
   (let* ((s (quiet-find-system name))
-         (deps (asdf:system-depends-on s)))
+         (deps (when s (asdf:system-depends-on s))))
     (dolist (d deps)
       (let ((dep (resolve-dependency-name d)))
         (handler-case

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -1225,10 +1225,32 @@ download the system unless a version is specified."
                  (string= (pathname-name system-file) name))
         system-file))))
 
+;; just to be safe, try loading internal SBCL systems in the event they're
+;; actually needed by a defsystem, since we're going to make these unloadable
+;; later.
+(dolist (system '(:sb-aclrepl
+                  :sb-bsd-sockets
+                  :sb-capstone
+                  :sb-cltl2
+                  :sb-concurrency
+                  :sb-cover
+                  :sb-executable
+                  :sb-gmp
+                  :sb-grovel
+                  :sb-introspect
+                  :sb-md5
+                  :sb-mpfr
+                  :sb-posix
+                  :sb-queue
+                  :sb-rotate-byte
+                  :sb-rt
+                  :sb-simple-streams
+                  :sb-sprof))
+  (ignore-errors (require system)))
+
 (setf asdf:*system-definition-search-functions*
       (append asdf:*system-definition-search-functions*
               (list 'system-definition-searcher)))
-
 
 ;; Register known internal systems as "immutable" so that find-system inside
 ;; the ocicl executable does not try to load them
@@ -1268,4 +1290,5 @@ download the system unless a version is specified."
                   :osi))
   (asdf:register-immutable-system system))
 
+;; clear systems to avoid collision with systems loaded into executable
 (asdf/system-registry:clear-registered-systems)

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -278,16 +278,15 @@ Distributed under the terms of the MIT License"
          (deps (asdf:system-depends-on s)))
     (dolist (d deps)
       (let ((dep (resolve-dependency-name d)))
-        (unless (string= "sb-" (subseq (string-downcase (format nil "~A" dep)) 0 3))
-          (handler-case
-              (download-system-dependencies dep)
-            (asdf/find-component:missing-component (e)
-              (declare (ignore e))
-              (when *verbose*
-                (format t "; can't download ASDF dependency ~A~%" d)))
-            (error (e)
-              (when *verbose*
-                (format t "; error processing ~A: ~A~%" d e)))))))))
+        (handler-case
+            (download-system-dependencies dep)
+          (asdf/find-component:missing-component (e)
+            (declare (ignore e))
+            (when *verbose*
+              (format t "; can't download ASDF dependency ~A~%" d)))
+          (error (e)
+            (when *verbose*
+              (format t "; error processing ~A: ~A~%" d e))))))))
 
 (defun do-latest (args)
   ;; Make sure the systems directory exists
@@ -1246,5 +1245,29 @@ download the system unless a version is specified."
 (setf asdf:*system-definition-search-functions*
       (append asdf:*system-definition-search-functions*
               (list 'system-definition-searcher)))
+
+;; Register known internal SBCL systems as "immutable" so that find-system
+;; inside the ocicl executable does not try to load them
+(dolist (system '(:sb-aclrepl
+                  :sb-bsd-sockets
+                  :sb-capstone
+                  :sb-cltl2
+                  :sb-concurrency
+                  :sb-cover
+                  :sb-executable
+                  :sb-gmp
+                  :sb-grovel
+                  :sb-introspect
+                  :sb-md5
+                  :sb-mpfr
+                  :sb-perf
+                  :sb-posix
+                  :sb-queue
+                  :sb-rotate-byte
+                  :sb-rt
+                  :sb-simd
+                  :sb-simple-streams
+                  :sb-sprof))
+  (asdf:register-immutable-system system))
 
 (asdf/system-registry:clear-registered-systems)


### PR DESCRIPTION
Previously we only built the top level dependency list based on systems registered in ocicl.csv, which did not fully consider e.g. slash systems in dependency resolution.

Additionally, the dependency tree traversal was incomplete.