### PR TITLE
Portability improvements

### DIFF
--- a/ocicl.asd
+++ b/ocicl.asd
@@ -30,13 +30,23 @@
   :version (:read-file-form "version.sexp")
   :serial t
   :components ((:module "runtime"
-                :components ((:static-file "asdf.lisp")
-                             (:static-file "ocicl-runtime.lisp")))
+                        :components ((:static-file "asdf.lisp")
+                                     (:static-file "ocicl-runtime.lisp")))
                (:file "package")
                (:file "ocicl" :depends-on ("runtime" "package")))
-  :depends-on (:with-user-abort :unix-opts :dexador :cl-json :cl-interpol :tar :tar/simple-extract :copy-directory :diff)
+  :depends-on ( :with-user-abort
+                :unix-opts :dexador :cl-json :cl-interpol :tar
+                :tar/simple-extract :copy-directory :diff
+
                 ;; sbcl internals
-                ;:sb-posix :sb-bsd-sockets :sb-rotate-byte :sb-cltl2 :sb-introspect :sb-concurrency :sb-sprof :sb-md5 :sb-introspect)
+                (:feature :sbcl :sb-posix)
+                (:feature :sbcl :sb-bsd-sockets)
+                (:feature :sbcl :sb-rotate-byte)
+                (:feature :sbcl :sb-cltl2)
+                (:feature :sbcl :sb-introspect)
+                (:feature :sbcl :sb-concurrency)
+                (:feature :sbcl :sb-sprof)
+                (:feature :sbcl :sb-md5))
   :build-operation "program-op"
   :build-pathname "ocicl"
   :entry-point "ocicl:main")

--- a/ocicl.asd
+++ b/ocicl.asd
@@ -30,12 +30,11 @@
   :version (:read-file-form "version.sexp")
   :serial t
   :components ((:module "runtime"
-                        :components ((:static-file "asdf.lisp")
-                                     (:static-file "ocicl-runtime.lisp")))
+                :components ((:static-file "asdf.lisp")
+                             (:static-file "ocicl-runtime.lisp")))
                (:file "package")
                (:file "ocicl" :depends-on ("runtime" "package")))
-  :depends-on ( :with-user-abort
-                :unix-opts :dexador :cl-json :cl-interpol :tar
+  :depends-on ( :with-user-abort :unix-opts :dexador :cl-json :cl-interpol :tar
                 :tar/simple-extract :copy-directory :diff
 
                 ;; sbcl internals

--- a/ocicl.asd
+++ b/ocicl.asd
@@ -34,9 +34,9 @@
                              (:static-file "ocicl-runtime.lisp")))
                (:file "package")
                (:file "ocicl" :depends-on ("runtime" "package")))
-  :depends-on (:with-user-abort :unix-opts :dexador :cl-json :cl-interpol :tar :tar/simple-extract :copy-directory :diff
+  :depends-on (:with-user-abort :unix-opts :dexador :cl-json :cl-interpol :tar :tar/simple-extract :copy-directory :diff)
                 ;; sbcl internals
-                :sb-posix :sb-bsd-sockets :sb-rotate-byte :sb-cltl2 :sb-introspect :sb-concurrency :sb-sprof :sb-md5 :sb-introspect)
+                ;:sb-posix :sb-bsd-sockets :sb-rotate-byte :sb-cltl2 :sb-introspect :sb-concurrency :sb-sprof :sb-md5 :sb-introspect)
   :build-operation "program-op"
   :build-pathname "ocicl"
   :entry-point "ocicl:main")

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -27,7 +27,7 @@
 
 (named-readtables:in-readtable :interpol-syntax)
 
-(require 'sb-introspect)
+;(require 'sb-introspect)
 
 (defvar *ocicl-registries* (list "ghcr.io/ocicl"))
 (defvar *ocicl-globaldir* nil)
@@ -50,12 +50,12 @@
 (defparameter +version+ #.(uiop:read-file-form "version.sexp"))
 
 (defparameter +runtime+
-  (let* ((runtime #.(uiop:read-file-string "runtime/ocicl-runtime.lisp"))
+  #.(let* ((runtime (uiop:read-file-string "runtime/ocicl-runtime.lisp"))
          (start (search "UNKNOWN" runtime)))
     (if start
         (concatenate 'string
                      (subseq runtime 0 start)
-                     +version+
+                     (uiop:read-file-form "version.sexp")
                      (subseq runtime (+ start 7)))
         runtime)))
 
@@ -92,7 +92,7 @@
                      arg
                      (progn
                        (usage)
-                       (sb-ext:exit :code 1))))))
+                       (uiop:quit 1))))))
 
 (defun unknown-option (condition)
   (format t "warning: ~s option is unknown!~%" (opts:option condition))
@@ -148,7 +148,7 @@ Distributed under the terms of the MIT License"
    :usage-of "ocicl"
    :args     "command"))
 
-(defvar *systems-dir* nil)
+(defvar *systems-dir* "")
 
 (defun debug-log (s)
   (when *verbose*
@@ -200,7 +200,7 @@ Distributed under the terms of the MIT License"
       (format t "; ~A(~A) not found~%" system registry))))
 
 (defun do-list (args)
-  (handler-case
+;  (handler-case
       (when args
         (dolist (system args)
           (loop for registry in *ocicl-registries*
@@ -211,9 +211,9 @@ Distributed under the terms of the MIT License"
                          (format t "~T~A~%" tag))
                        (return))))
           (format t "~%")))
-    (sb-int:broken-pipe (e)
-      (declare (ignore e))
-      ())))
+    ;(sb-int:broken-pipe (e)
+      ;(declare (ignore e))
+      ());))
 
 (defun get-ocicl-dir ()
   "Find the ocicl directory."
@@ -257,7 +257,7 @@ Distributed under the terms of the MIT License"
         (*error-output* (if *verbose*
                             *error-output*
                             (make-broadcast-stream))))
-    (handler-bind (((or warning sb-ext:compiler-note)
+    (handler-bind ((warning
                      (lambda (w)
                        (unless *verbose*
                          (muffle-warning w)))))
@@ -290,11 +290,11 @@ Distributed under the terms of the MIT License"
         (if (position #\: system)
             (progn
               (format uiop:*stderr* "Error: version tag specified for system ~A.~%" system)
-              (sb-ext:quit)))
+              (uiop:quit)))
         (unless (download-system (concatenate 'string system ":latest"))
             (progn
               (format uiop:*stderr* "Error: system ~A not found.~%" system)
-              (sb-ext:quit))
+              (uiop:quit))
             (download-system-dependencies system)))
       ;; Download latest versions of all systems.
       (let ((blobs (make-hash-table :test #'equal)))
@@ -339,7 +339,7 @@ Distributed under the terms of the MIT License"
                (error (e)
                  (declare (ignore e))
                  (format uiop:*stderr* "Error: directory ~A does not exist.~%" (car args))
-                 (sb-ext:quit)))
+                 (uiop:quit)))
           (uiop:chdir original-directory)))
       (let ((old-config-file (merge-pathnames (get-ocicl-dir) "ocicl-globaldir.cfg")))
         (when (probe-file old-config-file)
@@ -555,7 +555,7 @@ Distributed under the terms of the MIT License"
               (unless (download-and-install system)
                 (progn
                   (format uiop:*stderr* "Error: can't download ~A.~%" system)
-                  (sb-ext:quit))))
+                  (uiop:quit))))
           (let* ((slist (split-on-delimiter system #\:))
                  (name (car slist)))
             (when (download-system system)
@@ -575,6 +575,19 @@ Distributed under the terms of the MIT License"
                               (merge-pathnames path2)))))
     (or (not enough-directory)
         (eql :relative (first enough-directory)))))
+
+
+;; this function needs to be defined above its first use if it is inline
+(declaim (inline find-asd-files))
+(defun find-asd-files (dir)
+  "Recursively find all files with the .asd extension in a directory."
+  ;; Force a trailing slash to support uiop change in behavior:
+  ;; https://github.com/fare/asdf/commit/6138d709eb25bf75c1d1f7dc45a63d174f982321
+  (directory (merge-pathnames
+              (make-pathname :name :wild
+                             :type "asd"
+                             :directory '(:relative :wild-inferiors))
+              (uiop:ensure-directory-pathname dir))))
 
 (defun system-group (system)
   "Return systems that are known to ocicl and in the same directory tree as SYSTEM"
@@ -615,32 +628,32 @@ Distributed under the terms of the MIT License"
   (let* ((slist (split-on-delimiter system #\:))
          (name (car slist))
          (mangled-name (mangle name))
-         (system-info (gethash mangled-name *ocicl-systems*))
-         (fullname (car system-info))
-         (relative-asd-path (cdr system-info))
-         (absolute-asd-path (when system-info (merge-pathnames relative-asd-path *systems-dir*)))
-         (system-directory (when system-info
-                             (merge-pathnames
-                              (make-pathname
-                               :directory
-                               `(:relative
-                                 ,(second
-                                   (pathname-directory
-                                    (enough-namestring absolute-asd-path *systems-dir*)))))
-                              *systems-dir*)))
-         (system-group (system-group system)))
-    (unless system-info
-      (format t "; no system to remove: ~A~%" name))
-    (when (and modify-ocicl-systems system-info)
-      (dolist (system system-group)
-        (remhash system *ocicl-systems*)))
-    (when (and system-directory (uiop:directory-exists-p system-directory))
-      (uiop:delete-directory-tree
-       system-directory
-       :validate (lambda (path)
-                   ;; ensure directory being deleted is a subdirectory of *systems-dir*
-                   (equal :relative (car (pathname-directory (enough-namestring path *systems-dir*))))))
-      (format t "; removed ~A~%" (file-namestring fullname)))))
+         (system-info (gethash mangled-name *ocicl-systems*)))
+
+    (if (null system-info)
+      (format t "; no system to remove: ~A~%" name) ;return here, fixes type warnings to merge-pathnames
+      (let* ((fullname (car system-info))
+             (relative-asd-path (cdr system-info))
+             (absolute-asd-path (merge-pathnames relative-asd-path *systems-dir*))
+             (system-directory (merge-pathnames
+                                 (make-pathname
+                                   :directory
+                                   `(:relative
+                                      ,(second
+                                         (pathname-directory
+                                           (enough-namestring absolute-asd-path *systems-dir*)))))
+                                 *systems-dir*))
+             (system-group (system-group system)))
+        (when (and modify-ocicl-systems system-info)
+          (dolist (system system-group)
+            (remhash system *ocicl-systems*)))
+        (when (uiop:directory-exists-p system-directory)
+          (uiop:delete-directory-tree
+            system-directory
+            :validate (lambda (path)
+                        ;; ensure directory being deleted is a subdirectory of *systems-dir*
+                        (equal :relative (car (pathname-directory (enough-namestring path *systems-dir*))))))
+          (format t "; removed ~A~%" (file-namestring fullname)))))))
 
 (defun resolve-dependency-name (dependency)
   "Resolve ASDF dependency name."
@@ -821,11 +834,11 @@ Distributed under the terms of the MIT License"
 (defun do-diff (args)
   (declare (optimize (speed 3) (safety 1)))
   (if (fourth args)
-      (progn (usage) (sb-ext:exit :code 1))
+      (progn (usage) (uiop:quit 1))
       (let* ((system-name (first args))
              (given-v1 (second args))
              (given-v2 (third args))
-             (latest-version (when (or (string= given-v1 "latest")
+             (latest-version (when (or (equal given-v1 "latest")
                                        (equal given-v2 "latest")
                                        (and (null given-v1) (null given-v2)))
                                (system-latest-version system-name)))
@@ -855,7 +868,7 @@ Distributed under the terms of the MIT License"
                                                         :print-error t))))
           (when (not (or version1 version1-system-info))
             (format *error-output* "; Error: system ~A not installed. Install it or specify two versions to diff.~%" system-name)
-            (sb-ext:exit :code 1))
+            (uiop:quit :code 1))
           (if (and version1-system-info version2-system-info)
               (let* ((version1-dir (merge-pathnames
                                     (make-pathname
@@ -905,7 +918,7 @@ Distributed under the terms of the MIT License"
                                 (when (binary-files-differ-p pathname-1 pathname-2)
                                   (format t "~&Binary files ~a and ~a differ~%" pathname-1 pathname-2))))))
                       (format t "~&Only in ~a: ~a~%" (cdr file) (car file)))))
-              (sb-ext:exit :code 1))))))
+              (uiop:quit 1))))))
 
 (defmethod parent ((file pathname))
   "Return the parent directory of FILE."
@@ -982,12 +995,10 @@ Distributed under the terms of the MIT License"
                                         (and (not color)
                                              (not (uiop:getenvp "NO_COLOR"))))
                                     (handler-case
-                                        (not (zerop
-                                              (sb-unix:unix-isatty
-                                               (sb-sys:fd-stream-fd
-                                                (if  (typep *standard-output* 'synonym-stream)
-                                                     (symbol-value (synonym-stream-symbol *standard-output*))
-                                                     *standard-output*)))))
+                                        (interactive-stream-p
+                                          (if  (typep *standard-output* 'synonym-stream)
+                                            (symbol-value (synonym-stream-symbol *standard-output*))
+                                            *standard-output*))
                                       (error () nil))))))
 
 
@@ -1024,12 +1035,12 @@ Distributed under the terms of the MIT License"
                          ((string= cmd "version")
                           (do-version (cdr free-args)))
                          (t (usage)))))))))))
-    (with-user-abort:user-abort () (sb-ext:exit :code 130))
+    (with-user-abort:user-abort () (uiop:quit 130))
     (stream-error (e)
       (format *error-output* "ocicl: stream error during output~%")
       (when *verbose*
         (format *error-output* "~a~&" e))
-      (sb-ext:exit :code 1))))
+      (uiop:quit 1))))
 
 (defun replace-plus-with-string (str)
   (let ((mangled (with-output-to-string (s)
@@ -1053,16 +1064,6 @@ Distributed under the terms of the MIT License"
     (merge-pathnames (eval `(make-pathname :directory '(:relative ,rdir)))
                      (uiop:default-temporary-directory))))
 
-(declaim (inline find-asd-files))
-(defun find-asd-files (dir)
-  "Recursively find all files with the .asd extension in a directory."
-  ;; Force a trailing slash to support uiop change in behavior:
-  ;; https://github.com/fare/asdf/commit/6138d709eb25bf75c1d1f7dc45a63d174f982321
-  (directory (merge-pathnames
-              (make-pathname :name :wild
-                             :type "asd"
-                             :directory '(:relative :wild-inferiors))
-              (uiop:ensure-directory-pathname dir))))
 
 (defun extract-sha256 (str)
   (let* ((start (search "sha256:" str))
@@ -1228,26 +1229,27 @@ download the system unless a version is specified."
 ;; just to be safe, try loading internal SBCL systems in the event they're
 ;; actually needed by a defsystem, since we're going to make these unloadable
 ;; later.
-(handler-bind ((warning (lambda (c) (muffle-warning c))))
-  (dolist (system '(:sb-aclrepl
-                    :sb-bsd-sockets
-                    :sb-capstone
-                    :sb-cltl2
-                    :sb-concurrency
-                    :sb-cover
-                    :sb-executable
-                    :sb-gmp
-                    :sb-grovel
-                    :sb-introspect
-                    :sb-md5
-                    :sb-mpfr
-                    :sb-posix
-                    :sb-queue
-                    :sb-rotate-byte
-                    :sb-rt
-                    :sb-simple-streams
-                    :sb-sprof))
-    (ignore-errors (require system))))
+
+;(handler-bind ((warning (lambda (c) (muffle-warning c))))
+;  (dolist (system '(:sb-aclrepl
+;                    :sb-bsd-sockets
+;                    :sb-capstone
+;                    :sb-cltl2
+;                    :sb-concurrency
+;                    :sb-cover
+;                    :sb-executable
+;                    :sb-gmp
+;                    :sb-grovel
+;                    :sb-introspect
+;                    :sb-md5
+;                    :sb-mpfr
+;                    :sb-posix
+;                    :sb-queue
+;                    :sb-rotate-byte
+;                    :sb-rt
+;                    :sb-simple-streams
+;                    :sb-sprof))
+;    (ignore-errors (require system))))
 
 (setf asdf:*system-definition-search-functions*
       (append asdf:*system-definition-search-functions*
@@ -1256,25 +1258,25 @@ download the system unless a version is specified."
 ;; Register known internal systems as "immutable" so that find-system inside
 ;; the ocicl executable does not try to load them
 (dolist (system '(:sb-aclrepl
-                  :sb-bsd-sockets
-                  :sb-capstone
-                  :sb-cltl2
-                  :sb-concurrency
-                  :sb-cover
-                  :sb-executable
-                  :sb-gmp
-                  :sb-grovel
-                  :sb-introspect
-                  :sb-md5
-                  :sb-mpfr
-                  :sb-perf
-                  :sb-posix
-                  :sb-queue
-                  :sb-rotate-byte
-                  :sb-rt
-                  :sb-simd
-                  :sb-simple-streams
-                  :sb-sprof
+;                  :sb-bsd-sockets
+;                  :sb-capstone
+;                  :sb-cltl2
+;                  :sb-concurrency
+;                  :sb-cover
+;                  :sb-executable
+;                  :sb-gmp
+;                  :sb-grovel
+;                  :sb-introspect
+;                  :sb-md5
+;                  :sb-mpfr
+;                  :sb-perf
+;                  :sb-posix
+;                  :sb-queue
+;                  :sb-rotate-byte
+;                  :sb-rt
+;                  :sb-simd
+;                  :sb-simple-streams
+;                  :sb-sprof
 
                   ;; Register some non-SBCL internal systems that don't exist
                   ;; in the ocicl repo

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -27,8 +27,6 @@
 
 (named-readtables:in-readtable :interpol-syntax)
 
-;(require 'sb-introspect)
-
 (defvar *ocicl-registries* (list "ghcr.io/ocicl"))
 (defvar *ocicl-globaldir* nil)
 (defvar *verbose* nil)
@@ -200,20 +198,17 @@ Distributed under the terms of the MIT License"
       (format t "; ~A(~A) not found~%" system registry))))
 
 (defun do-list (args)
-;  (handler-case
-      (when args
-        (dolist (system args)
-          (loop for registry in *ocicl-registries*
-                do (let ((tags (system-version-list system registry)))
-                     (when tags
-                       (format t "~A(~A):~%~Tlatest~%" system registry)
-                       (dolist (tag tags)
-                         (format t "~T~A~%" tag))
-                       (return))))
-          (format t "~%")))
-    ;(sb-int:broken-pipe (e)
-      ;(declare (ignore e))
-      ());))
+  (when args
+    (dolist (system args)
+      (loop for registry in *ocicl-registries*
+            do (let ((tags (system-version-list system registry)))
+                 (when tags
+                   (format t "~A(~A):~%~Tlatest~%" system registry)
+                   (dolist (tag tags)
+                     (format t "~T~A~%" tag))
+                   (return))))
+      (format t "~%")))
+  ())
 
 (defun get-ocicl-dir ()
   "Find the ocicl directory."
@@ -1226,58 +1221,13 @@ download the system unless a version is specified."
                  (string= (pathname-name system-file) name))
         system-file))))
 
-;; just to be safe, try loading internal SBCL systems in the event they're
-;; actually needed by a defsystem, since we're going to make these unloadable
-;; later.
-
-;(handler-bind ((warning (lambda (c) (muffle-warning c))))
-;  (dolist (system '(:sb-aclrepl
-;                    :sb-bsd-sockets
-;                    :sb-capstone
-;                    :sb-cltl2
-;                    :sb-concurrency
-;                    :sb-cover
-;                    :sb-executable
-;                    :sb-gmp
-;                    :sb-grovel
-;                    :sb-introspect
-;                    :sb-md5
-;                    :sb-mpfr
-;                    :sb-posix
-;                    :sb-queue
-;                    :sb-rotate-byte
-;                    :sb-rt
-;                    :sb-simple-streams
-;                    :sb-sprof))
-;    (ignore-errors (require system))))
-
 (setf asdf:*system-definition-search-functions*
       (append asdf:*system-definition-search-functions*
               (list 'system-definition-searcher)))
 
 ;; Register known internal systems as "immutable" so that find-system inside
 ;; the ocicl executable does not try to load them
-(dolist (system '(:sb-aclrepl
-;                  :sb-bsd-sockets
-;                  :sb-capstone
-;                  :sb-cltl2
-;                  :sb-concurrency
-;                  :sb-cover
-;                  :sb-executable
-;                  :sb-gmp
-;                  :sb-grovel
-;                  :sb-introspect
-;                  :sb-md5
-;                  :sb-mpfr
-;                  :sb-perf
-;                  :sb-posix
-;                  :sb-queue
-;                  :sb-rotate-byte
-;                  :sb-rt
-;                  :sb-simd
-;                  :sb-simple-streams
-;                  :sb-sprof
-
+(dolist (system '(
                   ;; Register some non-SBCL internal systems that don't exist
                   ;; in the ocicl repo
 


### PR DESCRIPTION
As a first step to addressing #58, I made an attempt to increase the portability of the ocicl functionality by replacing all of the sbcl dependent code

Certain dependencies (such as bordeax threads) still aren't entirely portable across all implementations (in particular, CLISP), so future work might need to be done there if portability is an important requirement. 

Likely next steps:
- reduce the size of ocicl dependencies in order to make it easier to ship ocicl as a single file (ie, using monolithic-concatenate-source-op like asdf)
- merge `ocicl.lisp` and `runtime/ocicl-runtime.lisp` into one file, removing the need for a binary to be installed.

I also fixed several compilation warnings and notes I came across while building