### PR TITLE
New command: ocicl tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Choose from the following ocicl commands:
    list SYSTEM...                  List available system versions
    remove [SYSTEM]...              Remove systems
    setup [GLOBALDIR]               Mandatory ocicl configuration
+   tree [SYSTEM]...                Print tree of installed systems
    version                         Show the ocicl version information
 
 Distributed under the terms of the MIT License

--- a/ocicl.asd
+++ b/ocicl.asd
@@ -32,8 +32,9 @@
   :components ((:module "runtime"
                 :components ((:static-file "asdf.lisp")
                              (:static-file "ocicl-runtime.lisp")))
+               (:file "tree")
                (:file "package")
-               (:file "ocicl" :depends-on ("runtime" "package")))
+               (:file "ocicl" :depends-on ("runtime" "package" "tree")))
   :depends-on (:with-user-abort :unix-opts :dexador :cl-json :cl-interpol :tar :tar/simple-extract :copy-directory :diff
                 ;; sbcl internals
                 :sb-posix :sb-bsd-sockets :sb-rotate-byte :sb-cltl2 :sb-introspect :sb-concurrency :sb-sprof :sb-md5 :sb-introspect)

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -94,7 +94,7 @@
                        (usage)
                        (sb-ext:exit :code 1)))))
   (:name :depth
-   :description "maximum depth for the tree command"
+   :description "maximum depth for the tree command (integer or \"max\", default 1)"
    :short #\d
    :long "depth"
    :meta-var "NUM"
@@ -153,6 +153,7 @@
    list SYSTEM...                  List available system versions
    remove [SYSTEM]...              Remove systems
    setup [GLOBALDIR]               Mandatory ocicl configuration
+   tree [SYSTEM]...                Print tree of installed systems
    version                         Show the ocicl version information
 
 Distributed under the terms of the MIT License"

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -1028,7 +1028,11 @@ Distributed under the terms of the MIT License"
                   (mapcar
                    #'unmangle
                    (sort (alexandria:hash-table-keys *ocicl-systems*) #'string<))))))
-    (tree:print-tree top :unicode t :max-depth (+ *tree-depth* (if args 1 0))))
+    (tree:print-tree
+     top
+     :unicode t
+     :max-depth (when *tree-depth*
+                  (+ *tree-depth* (if args 1 0)))))
   (when *color*
     (write-string *color-reset*)))
 

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -680,7 +680,7 @@ Distributed under the terms of the MIT License"
            (progn
              (maphash (lambda (system info)
                         (declare (ignore info))
-                        (full-dependency-table system dependency-table))
+                        (full-dependency-table (unmangle system) dependency-table))
                       *ocicl-systems*)
              (alexandria:hash-table-alist dependency-table)))
          (seen-system-groups (make-hash-table :test #'equal)))

--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -1028,7 +1028,7 @@ Distributed under the terms of the MIT License"
                   (mapcar
                    #'unmangle
                    (sort (alexandria:hash-table-keys *ocicl-systems*) #'string<))))))
-    (tree:print-tree top :unicode t :max-depth *tree-depth*))
+    (tree:print-tree top :unicode t :max-depth (+ *tree-depth* (if args 1 0))))
   (when *color*
     (write-string *color-reset*)))
 

--- a/tree.lisp
+++ b/tree.lisp
@@ -27,6 +27,8 @@
   (let ((node (car nodes)))
     (when prefix
       (write-string prefix stream)
+      (when (> depth 1)
+        (write-string " "))
       (write-string
        (if (cdr nodes)
            node-prefix
@@ -45,6 +47,8 @@
                               :prefix
                               (if prefix
                                   (concatenate 'string prefix
+                                               (when (> depth 1)
+                                                  " ")
                                                (if (cdr nodes)
                                                    continue-prefix
                                                    "  "))

--- a/tree.lisp
+++ b/tree.lisp
@@ -1,0 +1,64 @@
+(defpackage tree
+  (:use :cl)
+  (:export
+   #:node-equal
+   #:node-children
+   #:print-node
+   #:print-tree))
+
+(in-package :tree)
+
+(defmethod node-equal ((node-1 t) (node-2 t))
+  (equal node-1 node-2))
+
+(defmethod print-node ((node t) stream)
+  (princ node stream))
+
+(defmethod node-children ((node t))
+  nil)
+
+(defun %print-tree (nodes stream &key
+                                   (last-node-prefix "`- ")
+                                   (node-prefix "|- ")
+                                   (continue-prefix "| ")
+                                   (max-depth nil)
+                                   (depth 0)
+                                   prefix)
+  (let ((node (car nodes)))
+    (when prefix
+      (write-string prefix stream)
+      (write-string
+       (if (cdr nodes)
+           node-prefix
+           last-node-prefix)
+       stream))
+    (print-node node stream)
+    (terpri)
+    (unless (and max-depth (>= depth max-depth))
+      (maplist (lambda (node)
+                 (%print-tree node stream
+                              :depth (1+ depth)
+                              :max-depth max-depth
+                              :last-node-prefix last-node-prefix
+                              :node-prefix node-prefix
+                              :continue-prefix continue-prefix
+                              :prefix
+                              (if prefix
+                                  (concatenate 'string prefix
+                                               (if (cdr nodes)
+                                                   continue-prefix
+                                                   "  "))
+                                  ;; handle the top case
+                                  "")))
+               (node-children node)))
+    (values)))
+
+(defun print-tree (node &key (stream *standard-output*)
+                          unicode
+                          (max-depth nil))
+  (if unicode
+      (%print-tree (list node) stream :node-prefix "├─ "
+                                      :last-node-prefix "└─ "
+                                      :continue-prefix "│ "
+                                      :max-depth max-depth)
+      (%print-tree (list node) stream :max-depth max-depth)))


### PR DESCRIPTION
- Adds fairly simple but extensible generic tree printer (supports ascii and unicode tree printing) in `tree.lisp`
- Prints installed systems in tree view
- Defaults to top systems in ocicl.csv, and depth = 1 (a flat list essentially)
- Allows specifying top systems to show
- Can specify --depth=n or --depth=max to show full tree
- Omits sub-trees for seen systems with indicator (but prints the seen system itself). This avoids ginormous trees and repetition of information.
- ❓ The  tree defaults to unicode right now, but maybe we should look at LANG to decide?

Uses extra characters and/or colors for more info:

- green means showing new system, dim means system was already printed (you lose this visual info in no-color mode, but I think that's okay since we're not re-printing the deps either way).
- `*` means previously expanded (and therefore previously printed)
- `!` (and red) means system is either not installed or could not be loaded (missing deps, just deleted from systems dir, error in defsystemfile, etc)

Here's a partial screenshot (wouldn't fit on one screen) of the default tree for this ocicl itself:
<img width="409" alt="Screenshot 2025-04-11 at 15 59 57" src="https://github.com/user-attachments/assets/d4f5347c-bfbc-4e94-9960-cd08b1bd2d89" />

Here's a partial screenshot with `--depth=4` (note the offset is now resolved):
<img width="341" alt="Screenshot 2025-04-11 at 16 01 51" src="https://github.com/user-attachments/assets/2b1d7cfa-e91c-42f6-a31d-9762469ecc7e" />