### PR TITLE
More colors

### DIFF
--- a/ocicl.lisp
+++ b/ocicl.lisp
@@ -738,14 +738,22 @@ If FORCE is NIL, skip files that already exist."
                (system-group (system-group system)))
           (when (and modify-ocicl-systems system-info)
             (dolist (system system-group)
-              (remhash system *ocicl-systems*)))
+              (remhash (mangle system) *ocicl-systems*)))
           (when (uiop:directory-exists-p system-directory)
             (uiop:delete-directory-tree
              system-directory
              :validate (lambda (path)
                          ;; ensure directory being deleted is a subdirectory of *systems-dir*
                          (equal :relative (car (pathname-directory (enough-namestring path *systems-dir*))))))
-            (format t "; removed ~A~%" (file-namestring fullname)))))))
+            (let* ((full-namestring (file-namestring fullname))
+                   (at (position #\@ full-namestring))
+                   (name (subseq full-namestring 0 at))
+                   (version-sha (subseq full-namestring at)))
+              (if *color*
+                  (format t #?"${*color-dim*};${*color-reset*} removed ~
+                               ${*color-bold*}${*color-bright-green*}${(unmangle name)}${*color-reset*}~
+                               ${*color-dim*}${version-sha}${*color-reset*}~%")
+                  (format t "; removed ~A@~A~%" (unmangle name) version-sha))))))))
 
 (defun resolve-dependency-name (dependency)
   "Resolve ASDF dependency name."


### PR DESCRIPTION
Adds colors to more ocicl commands (list, libyear, install, remove)

Eventually, it'd be nice to have a nicer paradigm (e.g. a custom format function) to optionally add colors, but I'm not sure what the best interface for this is, and existing packages that do this (e.g. cl-ansi-term) seemed to pull more deps than necessary. 

I can provide screenshots if wanted. I also changed a couple messages to make them more consistent/clearer (e.g. download**ed** vs download**ing**)