### PR TITLE
Download dependencies that resolve outside ocicl-managed dirs (#198)

### DIFF
--- a/src/ocicl.lisp
+++ b/src/ocicl.lisp
@@ -544,20 +544,47 @@ Tries bearer token first, falls back to Basic auth if credentials are configured
           (asdf:find-system system errorp)
           (asdf:find-system system)))))
 
-(defun download-system-dependencies (name)
+(defun download-system-dependencies (name &optional (visited (make-hash-table :test #'equal)))
+  "Recursively download NAME's dependencies into the local systems directory.
+
+We can't rely on FIND-SYSTEM alone to pull dependencies in for us: ASDF will
+happily resolve a dependency from anywhere in its source registry (a sibling
+project, a globally installed system, an .asd file sitting in the current
+directory, ...).  When that happens the dependency is never downloaded into the
+local systems directory.  So we use FIND-SYSTEM to read the dependency graph,
+but explicitly DOWNLOAD-SYSTEM any dependency that doesn't already live in an
+ocicl-managed systems directory (the local *SYSTEMS-DIR* or the shared global
+*GLOBAL-SYSTEMS-DIR*)."
   (let* ((s (quiet-find-system name))
          (deps (when s (asdf:system-depends-on s))))
     (dolist (d deps)
-      (let ((dep (resolve-dependency-name d)))
-        (handler-case
-            (download-system-dependencies dep)
-          (asdf/find-component:missing-component (e)
-            (declare (ignore e))
-            (when *verbose*
-              (format t "; can't download ASDF dependency ~A~%" d)))
-          (error (e)
-            (when *verbose*
-              (format t "; error processing ~A: ~A~%" d e))))))))
+      (let* ((dep (resolve-dependency-name d))
+             (depname (when dep (ignore-errors (asdf:coerce-name dep)))))
+        (when (and depname (not (gethash (mangle depname) visited)))
+          (setf (gethash (mangle depname) visited) t)
+          (handler-case
+              (let* ((dep-system (quiet-find-system depname nil))
+                     (source-file (and dep-system
+                                       (asdf:system-source-file dep-system))))
+                ;; Vendor the dependency unless it's a builtin/require module
+                ;; (no source file) or it already lives in an ocicl-managed
+                ;; systems directory.  The latter covers the local systems dir
+                ;; (including a parent project's, since FIND-WORKDIR points
+                ;; *SYSTEMS-DIR* there) as well as the shared global dir, so we
+                ;; don't re-download something that's already cached globally.
+                (when (and source-file
+                           (not (subpath-p source-file *systems-dir*))
+                           (not (and *global-systems-dir*
+                                     (subpath-p source-file *global-systems-dir*))))
+                  (download-system depname))
+                (download-system-dependencies depname visited))
+            (asdf/find-component:missing-component (e)
+              (declare (ignore e))
+              (when *verbose*
+                (format t "; can't download ASDF dependency ~A~%" d)))
+            (error (e)
+              (when *verbose*
+                (format t "; error processing ~A: ~A~%" d e)))))))))
 
 (defun do-latest (args)
   ;; Make sure the systems directory exists


### PR DESCRIPTION
Fixes #198.

## Problem

`ocicl install <system>` was not reliably downloading a system's dependencies. The reporter saw it most clearly with `OCICL_LOCAL_ONLY=1` in a fresh directory:

```bash
mkdir tst && cd tst
export OCICL_LOCAL_ONLY=1
ocicl install adopt      # adopt's deps :bobbin and :split-sequence were not all vendored
```

## Root cause

`download-system-dependencies` relied on `asdf:find-system` to pull dependencies in as a side effect — ocicl's downloader is wired into ASDF as a `system-definition-search-function`. But that search function is **appended** to `asdf:*system-definition-search-functions*`, so it runs **last**. If ASDF can resolve a dependency from anywhere else in its source registry first (a sibling project, a globally installed system, or — as the reporter suspected — an `.asd` file sitting in the working directory), `find-system` succeeds without ever invoking ocicl's downloader, and the dependency is silently never vendored into the local systems directory.

## Fix

Read the dependency graph with `find-system` as before, but explicitly `download-system` any dependency whose resolved `.asd` doesn't already live in an ocicl-managed systems directory:

- the local `*systems-dir*` (which `find-workdir` already points at a parent project's dir when an `ocicl.csv`/`systems.csv` lives above the cwd), or
- the shared global `*global-systems-dir*` (so globally cached deps are not needlessly re-downloaded locally).

Builtin/`:require` modules (no source file) are skipped, and a `visited` set dedupes diamond dependencies and prevents cycles.

## Testing

Manually verified against the dev build:

- `ocicl install adopt` (`OCICL_LOCAL_ONLY=1`) now vendors `adopt`, `bobbin`, and `split-sequence` locally.
- Same with a stray `myproj.asd` in the working directory.
- Deep transitive install (`drakma` → 12 systems) downloads everything, deduped, no loops.
- Re-running is idempotent.
- Parent-dir `ocicl.csv` walk-up: running from a subdir vendors deps into the parent's systems dir, leaving the subdir empty.
- Global dir: a dependency already installed in the global dir (`-g`) is resolved from there and **not** re-downloaded locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)